### PR TITLE
Have git ignore .o object files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ m4/submodules.m4
 *.exe
 *.obj
 *.log
+*.o


### PR DESCRIPTION
Object files are generated during the "make", "make install" process Since *.obj files were already ignored by git I am assuming some change in the compiler behavior possibly only on some platforms. The .o object files are removed by "make clean" but the Makefile is already ignored so this may be dependent on the system state when autogen.sh is run.